### PR TITLE
Fixing disarm query string

### DIFF
--- a/ext/alarmserver.js
+++ b/ext/alarmserver.js
@@ -158,7 +158,7 @@ function disarm() {
 	var code = prompt("What is your code?", "");
 	$.ajax({
 		type:"GET",
-		url:"/api/alarm/disarm?code" + code,
+		url:"/api/alarm/disarm?alarmcode=" + code,
 		contentType:"application/json; charset=utf-8",
 		dataType:"json",
 		data:"{}",


### PR DESCRIPTION
Fixing the disarm query string sent to application, variable name is wrong and was missing an equal sign. Tested and working properly when alarmcode is either wrong or not set in config file. Works great now with code provided via pop-up dialog.
