### PR TITLE
Updated 680 return code, added arm w/code and activate PGM output

### DIFF
--- a/alarmserver.py
+++ b/alarmserver.py
@@ -380,6 +380,15 @@ class AlarmServer(asyncore.dispatcher):
 		elif query.path == '/api/alarm/stayarm':
 			channel.pushok(json.dumps({'response' : 'Request to arm in stay received'}))
 			self._envisalinkclient.send_command('031', '1')
+		elif query.path == '/api/alarm/armwithcode':
+			channel.pushok(json.dumps({'response' : 'Request to arm with code received'}))
+			self._envisalinkclient.send_command('033', '1' + str(query_array['alarmcode'][0]))
+		elif query.path == '/api/pgm':
+			channel.pushok(json.dumps({'response' : 'Request to trigger PGM'}))
+			#self._envisalinkclient.send_command('020', '1' + str(query_array['pgmnum'][0]))
+			self._envisalinkclient.send_command('071', '1' + "*7" + str(query_array['pgmnum'][0]))
+			time.sleep(1)
+			self._envisalinkclient.send_command('071', '1' + str(query_array['alarmcode'][0]))
 		elif query.path == '/api/alarm/disarm':
 			channel.pushok(json.dumps({'response' : 'Request to disarm received'}))
 			if 'alarmcode' in query_array:

--- a/envisalinkdefs.py
+++ b/envisalinkdefs.py
@@ -56,6 +56,7 @@ evl_ResponseTypes = {
     672 : {'type' : 'partition', 'name' : 'Partition {0} Failure to Arm', 'description' : 'An attempt was made to arm the partition and it failed.'},
     673 : {'type' : 'partition', 'name' : 'Partition {0} is Busy', 'description' : 'The partition is busy (another keypad is programming or an installer is programming).'},
     674 : {'type' : 'partition', 'name' : 'Partition {0} System Arming in Progress', 'description' : 'This system is auto-arming and is in arm warning delay.'},
+    680 : {'name' : 'System in installers mode', 'description' : 'System has entered installers mode'},
     700 : {'type' : 'partition', 'name' : 'Partition {0[0]} User {0[1]}{0[2]}{0[3]}{0[4]} Closing', 'description' : 'A partition has been armed by a user - sent at the end of exit delay.', 'handler' : 'partition', 'status' : {'armed' : True, 'exit_delay' : False}},
     701 : {'type' : 'partition', 'name' : 'Partition {0} Special Closing', 'description' : 'A partition has been armed by one of the following methods: Quick Arm, Auto Arm, Keyswitch, DLS software, Wireless Key.', 'status' : {'armed' : True, 'exit_delay' : False}},
     702 : {'type' : 'partition', 'name' : 'Partition {0} Partial Closing', 'description' : 'A partition has been armed but one or more zones have been bypassed.', 'status' : {'armed' : True, 'exit_delay' : False}},

--- a/ext/alarmserver.js
+++ b/ext/alarmserver.js
@@ -145,7 +145,9 @@ function actions(obj) {
 		str += '<a class="btn" href="#" onclick="disarm();return false;">Disarm</a>';
 	} else if (!exit) {
 		str += '<a class="btn" href="#" onclick="doAction(\'arm\');return false;">Arm</a>';
+		str += '<a class="btn" href="#" onclick="armwithcode();return false;">Arm W/Code</a>';
 		str += '<a class="btn" href="#" onclick="doAction(\'stayarm\');return false;">Stay</a>';
+		str += '<a class="btn" href="#" onclick="pgm();return false;">PGM</a>';
 	}
 	if (exit) {
 		str += '<a class="btn" href="#" onclick="disarm();return false;">Cancel</a>';
@@ -159,6 +161,35 @@ function disarm() {
 	$.ajax({
 		type:"GET",
 		url:"/api/alarm/disarm?alarmcode=" + code,
+		contentType:"application/json; charset=utf-8",
+		dataType:"json",
+		data:"{}",
+		success:function (res) {
+			$.scojs_message(res.response, $.scojs_message.TYPE_OK);
+		}
+	});
+}
+
+function pgm() {
+	var pgmnum= prompt("Enter PGM # to trigger", "");
+	var code= prompt("What is your code?", "");
+	$.ajax({
+		type:"GET",
+		url:"/api/pgm?pgmnum=" + pgmnum + "&alarmcode=" + code,
+		contentType:"application/json; charset=utf-8",
+		dataType:"json",
+		data:"{}",
+		success:function (res) {
+			$.scojs_message(res.response, $.scojs_message.TYPE_OK);
+		}
+	});
+}
+
+function armwithcode() {
+	var code = prompt("What is your code?", "");
+	$.ajax({
+		type:"GET",
+		url:"/api/alarm/armwithcode?alarmcode=" + code,
 		contentType:"application/json; charset=utf-8",
 		dataType:"json",
 		data:"{}",


### PR DESCRIPTION
Retern code 680 added to indicate panel is in installers mode, without this the event code loop fails and never reconnects after receiving this code.

Added Arm with a code in addition to arming without (quick arm/Arm w/code).
Added ability to trigger a PGM output.

I'm not a great UI person so please feel free to change/remove my additions to the Web UI.
