### PR TITLE
Add option to log raw envisalink messages

### DIFF
--- a/alarmserver-example.cfg
+++ b/alarmserver-example.cfg
@@ -75,6 +75,9 @@ enableproxy=True
 proxyport=4025
 proxypass=user
 
+## Log raw envisalink messages
+lograwmessage=False
+
 ## Alarm code: If defined you can disarm the alarm without having to 
 ## enter a code. 
 alarmcode=1111

--- a/core/config.py
+++ b/core/config.py
@@ -28,6 +28,7 @@ class config():
         config.ENVISALINKHOST = config.read_config_var('envisalink', 'host', 'envisalink', 'str')
         config.ENVISALINKPORT = config.read_config_var('envisalink', 'port', 4025, 'int')
         config.ENVISALINKPASS = config.read_config_var('envisalink', 'pass', 'user', 'str')
+        config.ENVISALINKLOGRAW = config.read_config_var('envisalink', 'lograwmessage', False, 'bool')
         config.ENABLEPROXY = config.read_config_var('envisalink', 'enableproxy', True, 'bool')
         config.ENVISALINKPROXYPORT = config.read_config_var('envisalink', 'proxyport', config.ENVISALINKPORT, 'int')
         config.ENVISALINKPROXYPASS = config.read_config_var('envisalink', 'proxypass', config.ENVISALINKPASS, 'str')

--- a/core/envisalink.py
+++ b/core/envisalink.py
@@ -100,6 +100,9 @@ class Client(object):
     @gen.coroutine
     def handle_line(self, input):
         if input != '':
+            if config.ENVISALINKLOGRAW == True:
+                logger.debug('RX RAW < "' + str(input).strip() + '"')
+
             code=int(input[:3])
             parameters=input[3:][:-4]
             event = getMessageType(int(code))


### PR DESCRIPTION
Added option `lograwmessage` to log raw Envisalink messages for debugging and possibly replaying for testing.

The current handler logs the code with a text description but doesn't necessarily log the arguments.